### PR TITLE
Pin Flask-Login version to 0.2.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ psycopg2==2.5.4
 Flask==0.10.1
 
 # Flask Packages
+Flask-Login==0.2.11
 Flask-Migrate==1.4.0
 Flask-SQLAlchemy==2.0
 Flask-User==0.6.3


### PR DESCRIPTION
Later versions of Flask-Login turn `UserMixin.is_authenticated()` into a property and then code and templates break everywhere b/c of superfluous braces.

The (more complicated) alternative to this change would be to bump flask packages to current versions and remove the braces on all calls from this package.
