### PR TITLE
Updated requirements and templates for Flask-Login-v0.3+ compatibility

### DIFF
--- a/app/templates/core/home_page.html
+++ b/app/templates/core/home_page.html
@@ -5,7 +5,7 @@
 
 <p>This page is accessible to any user (signed in or not)</p>
 
-{% if not current_user.is_authenticated() %}
+{% if not current_user.is_authenticated %}
 <p>
 To view the User page, you must
 <a href="{{ url_for('user.login') }}">Sign in</a> or

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -26,7 +26,7 @@
         <div id="header-div" class="clearfix with-margins">
             <div class="pull-left"><a href="{{ url_for('core.home_page') }}"><span class="header-title">MyApp</span></a></div>
             <div class="pull-right">
-                {% if current_user.is_authenticated() %}
+                {% if current_user.is_authenticated %}
                     <a href="{{ url_for('core.user_profile_page') }}">{{ current_user.first_name or current_user.user_auth.username }}</a>
                     &nbsp; | &nbsp;
                     <a href="{{ url_for('user.logout') }}">Sign out</a>

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ Flask==0.10.1
 # Flask Packages
 Flask-Migrate==1.4.0
 Flask-SQLAlchemy==2.0
-Flask-User==0.6.3
+Flask-User==0.6.8
 Flask-WTF==0.12
 
 # Development tools


### PR DESCRIPTION
**Issue(s) Addressed:**

Current master branch is incompatible with Flask-Login-v0.3+, which causes errors of the type:

{% if current_user.is_authenticated() %}
E AttributeError: 'bool' object has no attribute 'call'
app/templates/layout.html:29: AttributeError
================================== 1 failed in 0.83 seconds ===================================

when, for example, running the unit-tests.

**Change Log:**

1. Updated requirements to require Flask-User 0.6.8+ for compatibility with Flask-Login-v0.3+
2. Substituted broken "is_authenticated()" calls in default templates to "is_authenticated" for Flask-Login-v0.3+ compatibility.
3. Unit tests now pass following README.md instructions from start to finish (mkvirtualenv, pip install -r requirements.txt, etc)