### PR TITLE
Fixing Python3 error message

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,4 +10,4 @@ manager = Manager(app)          # Setup Flask-Script
 db = SQLAlchemy()               # Setup Flask-SQLAlchemy
 
 from app.create_app import create_app, create_users
-import manage_commands
+from .manage_commands import init_db      # Explicit import to work with Python3


### PR DESCRIPTION
Actual error is:
```
import manage_commands
ImportError: No module named 'manage_commands'
```
Explicit importing fixes this