### PR TITLE
Update required Flask-WTF 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ Flask-Login==0.4.0
 Flask-Migrate==2.0.2
 Flask-Script==2.0.5
 Flask-SQLAlchemy==2.4.0
-Flask-WTF==0.14.2
+Flask-WTF==0.14.3
 Flask-User==1.0.1.5
 
 # Automated tests


### PR DESCRIPTION
Fixes #41  _ImportError: cannot import name 'url_encode'_ by updating Flask-WTF 0.14.2 to 0.14.3